### PR TITLE
fix laravel-admin-extensions/multi-language/ #9

### DIFF
--- a/src/Middlewares/MultiLanguageMiddleware.php
+++ b/src/Middlewares/MultiLanguageMiddleware.php
@@ -11,6 +11,8 @@ class MultiLanguageMiddleware
 {
     public function handle($request, Closure $next)
     {
+        config(['admin.auth.excepts' => ['auth/login','locale']]);
+        
         $languages = MultiLanguage::config('languages');
         $cookie_name = MultiLanguage::config('cookie-name', 'locale');
 


### PR DESCRIPTION
因 [Authenticate Middleware](https://github.com/z-song/laravel-admin/blob/master/src/Middleware/Authenticate.php) 進行驗證導致locale api不如預期運作
故在該元件運作時於路徑排除清單內加入該api endpoint